### PR TITLE
Fix acl rule

### DIFF
--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -17,7 +17,7 @@ class Index extends Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Eadesigndev_RomCity::romcity';
+    const ADMIN_RESOURCE = 'Eadesigndev_RomCity::romcity_list';
 
     private $resultPageFactory;
 

--- a/Controller/Adminhtml/Index/Region.php
+++ b/Controller/Adminhtml/Index/Region.php
@@ -17,7 +17,7 @@ class Region extends Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Eadesigndev_RomCity::romcity';
+    const ADMIN_RESOURCE = 'Eadesigndev_RomCity::region_list';
 
     protected $resultPageFactory;
 

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+	<acl>
+		<resources>
+			<resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::eadesign" title="EaDesign EaCore">
+					<resource id="Eadesigndev_RomCity::romcity" title="RomCity">
+						<resource id="Eadesigndev_RomCity::romcity_list" title="Manage City List" sortOrder="10" />
+						<resource id="Eadesigndev_RomCity::region_list" title="Manage Region List" sortOrder="20" />
+					</resource>
+				</resource>
+			</resource>
+		</resources>
+	</acl>
+</config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -7,11 +7,11 @@
 
         <add id="Eadesigndev_RomCity::romcity_list" title="Manage City List" module="Eadesigndev_RomCity" sortOrder="10"
              parent="Eadesigndev_RomCity::romcity" action="manage_romcity/index"
-             resource="Eadesigndev_RomCity::romcity"/>
+             resource="Eadesigndev_RomCity::romcity_list"/>
 
         <add id="Eadesigndev_RomCity::region_list" title="Manage Region List" module="Eadesigndev_RomCity" sortOrder="20"
              parent="Eadesigndev_RomCity::romcity" action="manage_romcity/index/region"
-             resource="Eadesigndev_RomCity::romcity"/>
+             resource="Eadesigndev_RomCity::region_list"/>
 
     </menu>
 </config>


### PR DESCRIPTION
When you create a role without EaDesign EaCore permission check, the menu item is always displayed in admin

Here is a video how you can replicate it

https://user-images.githubusercontent.com/19170814/124854818-8cb47c80-df6d-11eb-931d-af5e1792667e.mp4




